### PR TITLE
instroduced process_create_user, which handles the creation of a new…

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,15 @@ pub enum StakingError {
     /// Account already initialized
     #[error("Account already initialized")]
     AlreadyInitialized,
+    /// Invalid user storage PDA account
+    #[error("Invalid user storage PDA")]
+    InvalidUserStoragePda,
+    /// Invalid SystemProgram account
+    #[error("Invalid SystemProgram account")]
+    SystemProgramMismatch,
+    /// Account is not initialized
+    #[error("Account is not initialized")]
+    NotInitialized,
 }
 
 impl From<StakingError> for ProgramError {

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -3,13 +3,17 @@ use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
     msg,
+    program::invoke_signed,
+    program_error::ProgramError,
     program_pack::IsInitialized,
     pubkey::Pubkey,
+    system_instruction, system_program,
+    sysvar::{rent::Rent, Sysvar},
 };
 
 use crate::instruction::Instruction;
-use crate::state::PoolStorageAccount;
-use crate::error::StakingError;
+use crate::state::{PoolStorageAccount, UserStorageAccount, USER_STORAGE_TOTAL_BYTES};
+use crate::{error::StakingError, state};
 
 pub fn process(
     program_id: &Pubkey,
@@ -22,6 +26,10 @@ pub fn process(
         Instruction::Initialize { rewards_per_token } => {
             msg!("Initialize pool");
             process_initialize_pool(program_id, accounts, rewards_per_token)
+        }
+        Instruction::CreateUser {} => {
+            msg!("Create signer");
+            process_create_user(program_id, accounts)
         }
         _ => Err(StakingError::InvalidInstruction.into()),
     }
@@ -57,6 +65,73 @@ fn process_initialize_pool(
     user_storage_data.serialize(&mut &mut storage.data.borrow_mut()[..])?;
 
     msg!("Staking pool is initialized {:#?}", user_storage_data);
+
+    Ok(())
+}
+
+fn process_create_user(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+    let signer = next_account_info(accounts_iter)?;
+    if !signer.is_signer {
+        return Err(StakingError::InvalidSigner.into());
+    }
+
+    let user_storage_pda_account = next_account_info(accounts_iter)?;
+    let (pda, bump_seed) = Pubkey::find_program_address(&[signer.key.as_ref()], program_id);
+    if pda != *user_storage_pda_account.key {
+        return Err(StakingError::InvalidUserStoragePda.into());
+    }
+
+    let system_program_account = next_account_info(accounts_iter)?;
+    if !system_program::check_id(system_program_account.key) {
+        return Err(StakingError::SystemProgramMismatch.into());
+    }
+
+    let rent_lamports = Rent::get()?.minimum_balance(USER_STORAGE_TOTAL_BYTES);
+    msg!(
+        "signer have to pay {} lamports for rent exemption of {} bytes",
+        rent_lamports,
+        state::USER_STORAGE_TOTAL_BYTES
+    );
+
+    invoke_signed(
+        &system_instruction::create_account(
+            signer.key,
+            user_storage_pda_account.key,
+            rent_lamports,
+            USER_STORAGE_TOTAL_BYTES.try_into().unwrap(),
+            program_id,
+        ),
+        &[
+            signer.clone(),
+            user_storage_pda_account.clone(),
+            system_program_account.clone(),
+        ],
+        &[&[signer.key.as_ref(), &[bump_seed]]],
+    )?;
+
+    let mut user_storage_data =
+        UserStorageAccount::try_from_slice(&user_storage_pda_account.data.borrow())?;
+    if user_storage_data.is_initialized() {
+        return Err(ProgramError::AccountAlreadyInitialized);
+    }
+
+    user_storage_data.staked = 0;
+    user_storage_data.last_stake_timestamp = 0i64;
+    user_storage_data.is_initialized = true;
+
+    user_storage_data.serialize(&mut &mut user_storage_pda_account.data.borrow_mut()[..])?;
+
+    let pool_storage_account = next_account_info(accounts_iter)?;
+    let mut pool_storage_data =
+        PoolStorageAccount::try_from_slice(&pool_storage_account.data.borrow())?;
+    if !pool_storage_data.is_initialized() {
+        return Err(StakingError::NotInitialized.into());
+    }
+
+    pool_storage_data.user_count += 1;
+
+    pool_storage_data.serialize(&mut &mut pool_storage_account.data.borrow_mut()[..])?;
 
     Ok(())
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_program::{program_pack::IsInitialized, pubkey::Pubkey};
+use solana_program::{program_pack::IsInitialized, pubkey::Pubkey, clock::UnixTimestamp};
 
 /// Define the type of state stored in
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
@@ -16,6 +16,24 @@ pub is_initialized: bool,
 pub const POOL_STORAGE_TOTAL_BYTES: usize = 32 + 8 + 8 + 8 + 1;
 
 impl IsInitialized for PoolStorageAccount {
+    fn is_initialized(&self) -> bool {
+        self.is_initialized
+    }
+}
+
+/// Defines schema of user storage account
+///
+/// Storage size: 8 + 8 + 1 = 16 [reference](https://www.anchor-lang.com/docs/space)
+#[derive(BorshDeserialize, BorshSerialize, Debug)]
+pub struct UserStorageAccount {
+    pub staked: u64,
+    pub last_stake_timestamp: UnixTimestamp,
+
+    pub is_initialized: bool,
+}
+pub const USER_STORAGE_TOTAL_BYTES: usize = 8 + 8 + 1;
+
+impl IsInitialized for UserStorageAccount {
     fn is_initialized(&self) -> bool {
         self.is_initialized
     }


### PR DESCRIPTION
… user account for staking.

It ensures that each user has a unique, program-derived, rent-exempt account for tracking staking-related data securely and independently.